### PR TITLE
[Refactor/#53] Service 조회 API 성능 개선

### DIFF
--- a/MEME-DOMAIN/src/main/java/org/meme/domain/entity/Artist.java
+++ b/MEME-DOMAIN/src/main/java/org/meme/domain/entity/Artist.java
@@ -55,16 +55,5 @@ public class Artist extends User {
         this.portfolioList.add(portfolio);
     }
 
-
-//    public void tempMethod(){
-//        this.username = "name";
-//        this.email="";
-//        this.password="";
-//        this.workExperience=WorkExperience.FIVE;
-//        this.role="ARTIST";
-//        this.userStatus = UserStatus.ACTIVE;
-//        this.provider = Provider.KAKAO;
-//        this.details = false;
-//    }
 }
 

--- a/MEME-DOMAIN/src/main/java/org/meme/domain/entity/Model.java
+++ b/MEME-DOMAIN/src/main/java/org/meme/domain/entity/Model.java
@@ -42,39 +42,4 @@ public class Model extends User {
     @OneToMany(mappedBy = "model")
     private List<Reservation> reservations;
 
-    public void updateFavoriteArtistList(FavoriteArtist artist){
-        this.favoriteArtistList.add(artist);
-    }
-
-    public void updateFavoritePortfolioList(FavoritePortfolio portfolio){
-        this.favoritePortfolioList.add(portfolio);
-    }
-    public void updateReservationList(Reservation reservation){
-        this.reservationList.add(reservation);
-    }
-
-    public void updateReviewList(Review review){
-        this.reviewList.add(review);
-    }
-
-
-    //temp create model builder
-//    public static Model from(ModelProfileDto dto){
-//        return Model.builder()
-//                .profileImg(dto.getProfileImg())
-//                .nickname(dto.getNickname())
-//                .gender(dto.getGender())
-//                .skinType(dto.getSkinType())
-//                .personalColor(dto.getPersonalColor())
-//                .build();
-//    }
-
-//    public void tempMethod(){
-//        this.username = "name";
-//        this.email="";
-//        this.password="";
-//        this.role="MODEL";
-//        this.userStatus = UserStatus.ACTIVE;
-//        this.provider = Provider.KAKAO;
-//    }
 }

--- a/MEME-DOMAIN/src/main/java/org/meme/domain/entity/User.java
+++ b/MEME-DOMAIN/src/main/java/org/meme/domain/entity/User.java
@@ -73,24 +73,4 @@ public class User {
 
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "user")
     protected List<Inquiry> inquiryList;
-
-    public boolean getDetails() {
-        return details;
-    }
-
-    public void updateInquiryList(Inquiry inquiry){
-        this.inquiryList.add(inquiry);
-    }
-
-    public void updateProfileImg(String profileimg){
-        this.profileImg = profileimg;
-    }
-
-    public void updateNickname(String nickname){
-        this.nickname = nickname;
-    }
-
-    public void updateGender(Gender gender){
-        this.gender = gender;
-    }
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/common/status/ErrorStatus.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/common/status/ErrorStatus.java
@@ -19,6 +19,8 @@ public enum ErrorStatus implements BaseErrorCode {
      * Code : 400
      * Bad Request
      */
+    OVERFLOW_ARTIST_INTRODUCTION(HttpStatus.BAD_REQUEST, 400, "아티스트의 소개글은 500자 이하여야 합니다."),
+
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, 400,  "유효하지 않은 요청입니다."),
     ALREADY_EXIST_FAVORITE_ARTIST(HttpStatus.BAD_REQUEST, 400, "해당 아티스트는 이미 관심 아티스트로 등록되어있습니다."),
     ALREADY_EXIST_FAVORITE_PORTFOLIO(HttpStatus.BAD_REQUEST, 400, "해당 포트폴리오는 이미 관심 포트폴리오로 등록되어있습니다."),

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/converter/ArtistConverter.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/converter/ArtistConverter.java
@@ -33,12 +33,14 @@ public class ArtistConverter {
     }
 
     public static ArtistResponse.ArtistSimpleDto toArtistSimpleDto(Artist artist, Long modelCount) {
+         String region = artist.getRegion().isEmpty() ? null : artist.getRegion().get(0).getValue();
+
         return ArtistResponse.ArtistSimpleDto.builder()
                 .artistId(artist.getUserId())
                 .profileImg(artist.getUser().getProfileImg())
                 .artistNickName(artist.getUser().getNickname())
                 .email(artist.getUser().getEmail())
-                .region(artist.getRegion().get(0).getValue())
+                .region(region)
                 .modelCount(modelCount)
                 .build();
     }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/converter/PortfolioConverter.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/converter/PortfolioConverter.java
@@ -48,7 +48,7 @@ public class PortfolioConverter {
                 .isBlock(portfolio.isBlock())
                 .portfolioImgDtoList(portfolioImgDtoList)
                 .averageStars(portfolio.getAverageStars())
-                .reviewCount(portfolio.getReviewList().size())
+                .reviewCount(portfolio.getReviewList().size()) // TODO: count 쿼리 줄일 수 있는 방법 고안 필요
                 .build();
     }
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/converter/PortfolioConverter.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/converter/PortfolioConverter.java
@@ -21,6 +21,7 @@ public class PortfolioConverter {
                 .price(dto.getPrice())
                 .portfolioImgList(new ArrayList<PortfolioImg>())
                 .averageStars("0.00")
+                .reviewCount(0L)
                 .durationTime(dto.getDurationTime())
                 .isBlock(false)
                 .build();
@@ -48,7 +49,7 @@ public class PortfolioConverter {
                 .isBlock(portfolio.isBlock())
                 .portfolioImgDtoList(portfolioImgDtoList)
                 .averageStars(portfolio.getAverageStars())
-                .reviewCount(portfolio.getReviewList().size()) // TODO: count 쿼리 줄일 수 있는 방법 고안 필요
+                .reviewCount(portfolio.getReviewCount())
                 .build();
     }
 
@@ -77,7 +78,7 @@ public class PortfolioConverter {
                     .isBlock(portfolio.isBlock())
                     .portfolioImgDtoList(portfolioImgDtoList)
                     .averageStars(portfolio.getAverageStars())
-                    .reviewCount(portfolio.getReviewList().size())
+                    .reviewCount(portfolio.getReviewCount())
                     .durationTime(portfolio.getDurationTime())
                     .build();
     }
@@ -128,18 +129,6 @@ public class PortfolioConverter {
 
     public static PortfolioResponse.PortfolioSimpleDto toPortfolioSimpleDto(FavoritePortfolio favoritePortfolio){
         Portfolio portfolio = favoritePortfolio.getPortfolio();
-        Artist artist = portfolio.getArtist();
-
-        return PortfolioResponse.PortfolioSimpleDto.builder()
-                .portfolioId(portfolio.getPortfolioId())
-                .portfolioImg(portfolio.getPortfolioImgList().get(0).getSrc())
-                .category(portfolio.getCategory())
-                .makeupName(portfolio.getMakeupName())
-                .artistName(artist.getUser().getNickname())
-                .artistEmail(artist.getUser().getEmail())
-                .price(portfolio.getPrice())
-                .makeupLocation(artist.getMakeupLocation())
-                .averageStars(portfolio.getAverageStars())
-                .build();
+        return toPortfolioSimpleDto(portfolio);
     }
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/dto/response/PortfolioResponse.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/dto/response/PortfolioResponse.java
@@ -29,7 +29,7 @@ public class PortfolioResponse {
         private List<Region> region; //활동 가능 지역
         private Boolean isBlock;
         private String averageStars;
-        private int reviewCount; //리뷰 개수
+        private Long reviewCount; //리뷰 개수
         private List<PortfolioImgDto> portfolioImgDtoList;
     }
 
@@ -51,7 +51,7 @@ public class PortfolioResponse {
         private List<Region> region; //활동 가능 지역
         private Boolean isBlock;
         private String averageStars;
-        private int reviewCount; //리뷰 개수
+        private Long reviewCount; //리뷰 개수
         private String durationTime; //소요 시간
         private List<PortfolioImgDto> portfolioImgDtoList;
     }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Artist.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Artist.java
@@ -4,9 +4,6 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import lombok.experimental.SuperBuilder;
-import org.meme.service.domain.entity.Portfolio;
 import org.meme.service.domain.enums.*;
 
 import java.util.List;
@@ -14,7 +11,7 @@ import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
-@Getter @Setter
+@Getter
 @Entity
 public class Artist {
 
@@ -63,15 +60,40 @@ public class Artist {
         this.portfolioList.add(portfolio);
     }
 
-    public void updateProfileImg(String profileimg){
-        this.user.updateProfileImg(profileimg);
+    public void updateIntroduction(String introduction) {
+        if (!introduction.isEmpty()) {
+            this.introduction = introduction;
+        }
     }
 
-    public void updateNickname(String nickname){
-        this.user.updateNickname(nickname);
+    public void updateWorkExperience(WorkExperience workExperience) {
+        if (workExperience != null) {
+            this.workExperience = workExperience;
+        }
     }
 
-    public void updateGender(Gender gender){
-        this.user.updateGender(gender);
+    public void updateRegion(List<Region> region) {
+        if (!region.isEmpty()) {
+            this.region = region;
+        }
     }
+
+    public void updateSpecialization(List<Category> specialization) {
+        if (!specialization.isEmpty()) {
+            this.specialization = specialization;
+        }
+    }
+
+    public void updateMakeupLocation(MakeupLocation makeupLocation) {
+        if (makeupLocation != null) {
+            this.makeupLocation = makeupLocation;
+        }
+    }
+
+    public void updateShopLocation(String shopLocation) {
+        if (!shopLocation.isEmpty()) {
+            this.shopLocation = shopLocation;
+        }
+    }
+
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/FavoriteArtist.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/FavoriteArtist.java
@@ -19,7 +19,7 @@ public class FavoriteArtist extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long favoriteArtistId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id", nullable = false)
     private Model model;
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/FavoriteArtist.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/FavoriteArtist.java
@@ -23,6 +23,7 @@ public class FavoriteArtist extends BaseEntity {
     @JoinColumn(name="user_id", nullable = false)
     private Model model;
 
+    // TODO:
     @OneToOne
     private Artist artist;
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/FavoritePortfolio.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/FavoritePortfolio.java
@@ -21,11 +21,11 @@ public class FavoritePortfolio extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long favoritePortfolioId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id", nullable = false)
     private Model model;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="portfolio_id", nullable = false)
     private Portfolio portfolio;
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Inquiry.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Inquiry.java
@@ -28,7 +28,7 @@ public class Inquiry extends BaseEntity {
     @Column(nullable = false)
     private String email;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Model.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Model.java
@@ -4,15 +4,12 @@ import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
-import org.meme.service.domain.entity.*;
-import org.meme.service.domain.enums.Gender;
 import org.meme.service.domain.enums.PersonalColor;
 import org.meme.service.domain.enums.SkinType;
 
 import java.util.List;
 
-@Getter @Setter
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
@@ -58,16 +55,14 @@ public class Model {
         this.reviewList.add(review);
     }
 
-    public void updateProfileImg(String profileimg){
-        this.user.updateProfileImg(profileimg);
+    public void updateSkinType(SkinType skinType) {
+        if (skinType != null)
+            this.skinType = skinType;
     }
 
-    public void updateNickname(String nickname){
-        this.user.updateNickname(nickname);
+    public void updatePersonalColor(PersonalColor personalColor) {
+        if (personalColor != null) {
+            this.personalColor = personalColor;
+        }
     }
-
-    public void updateGender(Gender gender){
-        this.user.updateGender(gender);
-    }
-
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Portfolio.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Portfolio.java
@@ -53,6 +53,9 @@ public class Portfolio extends BaseEntity {
     @Column(nullable = false, columnDefinition = "TINYINT(1) default 0")
     private boolean isBlock;
 
+    @Column
+    private Long reviewCount;
+
     @BatchSize(size = 50)
     @OneToMany(mappedBy = "portfolio")
     private List<Review> reviewList;
@@ -114,6 +117,10 @@ public class Portfolio extends BaseEntity {
 
     public void updateBlock(boolean isBlock) {
         this.isBlock = isBlock;
+    }
+
+    public void updateReviewCount() {
+        this.reviewCount++;
     }
 
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Portfolio.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Portfolio.java
@@ -12,7 +12,7 @@ import java.util.List;
 
 
 @Builder
-@Getter @Setter
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 @Entity
@@ -57,14 +57,9 @@ public class Portfolio extends BaseEntity {
     @OneToMany(mappedBy = "portfolio")
     private List<Reservation> reservations;
 
-    public void updateReservationList(Reservation reservation){
-        this.reservations.add(reservation);
-    }
-
     public boolean isBlock(){
         return this.isBlock;
     }
-
 
     public void updateReviewList(Review review){
         this.reviewList.add(review);
@@ -91,4 +86,32 @@ public class Portfolio extends BaseEntity {
         this.portfolioImgList.add(portfolioImg);
         portfolioImg.setPortfolio(this);
     }
+
+    public void updateCategory(Category category) {
+        if (category != null)
+            this.category = category;
+    }
+
+    public void updatePrice(int price) {
+        if (price >= 0)
+            this.price = price;
+    }
+
+    public void updateInfo(String info) {
+        if (!info.isEmpty()) {
+            this.info = info;
+        }
+    }
+
+    public void updateMakeupName(String makeupName) {
+        if (!makeupName.isEmpty()) {
+            this.makeupName = makeupName;
+        }
+    }
+
+    public void updateBlock(boolean isBlock) {
+        this.isBlock = isBlock;
+    }
+
+
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Portfolio.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Portfolio.java
@@ -4,9 +4,6 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.BatchSize;
 import org.meme.service.common.BaseEntity;
-import org.meme.service.domain.entity.Artist;
-import org.meme.service.domain.entity.Reservation;
-import org.meme.service.domain.entity.Review;
 import org.meme.service.domain.enums.Category;
 
 import java.util.List;
@@ -121,6 +118,10 @@ public class Portfolio extends BaseEntity {
 
     public void updateReviewCount() {
         this.reviewCount++;
+    }
+
+    public void decreaseReviewCount() {
+        this.reviewCount--;
     }
 
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Portfolio.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Portfolio.java
@@ -2,6 +2,7 @@ package org.meme.service.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.BatchSize;
 import org.meme.service.common.BaseEntity;
 import org.meme.service.domain.entity.Artist;
 import org.meme.service.domain.entity.Reservation;
@@ -42,6 +43,7 @@ public class Portfolio extends BaseEntity {
     @Column(nullable = false)
     private String durationTime; //소요시간
 
+    @BatchSize(size = 10)
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "portfolio")
     private List<PortfolioImg> portfolioImgList;
 
@@ -51,6 +53,7 @@ public class Portfolio extends BaseEntity {
     @Column(nullable = false, columnDefinition = "TINYINT(1) default 0")
     private boolean isBlock;
 
+    @BatchSize(size = 50)
     @OneToMany(mappedBy = "portfolio")
     private List<Review> reviewList;
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/PortfolioImg.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/PortfolioImg.java
@@ -14,7 +14,7 @@ public class PortfolioImg extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long portfolioImgId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="portfolio_id", nullable = false)
     private Portfolio portfolio;
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Reservation.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Reservation.java
@@ -21,11 +21,11 @@ public class Reservation extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long reservationId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
     private Model model;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "portfolio_id", nullable = false)
     private Portfolio portfolio;
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Review.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/Review.java
@@ -18,11 +18,11 @@ public class Review extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long reviewId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="portfolio_id", nullable = false)
     private Portfolio portfolio;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="user_id", nullable = false)
     private Model model;
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/ReviewImg.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/ReviewImg.java
@@ -14,7 +14,7 @@ public class ReviewImg extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long reviewImgId;
 
-    @ManyToOne
+    @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name="review_id", nullable = false)
     private Review review;
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/User.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/entity/User.java
@@ -87,6 +87,7 @@ public class User {
     }
 
     public void updateGender(Gender gender){
-        this.gender = gender;
+        if (gender != null)
+            this.gender = gender;
     }
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/ArtistRepository.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/ArtistRepository.java
@@ -2,11 +2,20 @@ package org.meme.service.domain.repository;
 
 import org.meme.service.domain.entity.Artist;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
 public interface ArtistRepository extends JpaRepository<Artist, Long> {
+
+    @Query("SELECT a " +
+            "FROM Artist a " +
+            "JOIN FETCH a.user u " +
+            "JOIN FETCH a.portfolioList pl " +
+            "WHERE a.userId = :userId")
+    Optional<Artist> findArtistByUserId(@Param(value = "userId") Long userId);
 
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/FavoriteArtistRepository.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/FavoriteArtistRepository.java
@@ -2,8 +2,13 @@ package org.meme.service.domain.repository;
 
 import org.meme.service.domain.entity.Artist;
 import org.meme.service.domain.entity.FavoriteArtist;
+import org.meme.service.domain.entity.FavoritePortfolio;
 import org.meme.service.domain.entity.Model;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -15,4 +20,14 @@ public interface FavoriteArtistRepository extends JpaRepository<FavoriteArtist, 
     boolean existsByModelAndArtist(Model model, Artist artist);
     Optional<FavoriteArtist> findByModelAndArtist(Model model, Artist artist);
     Long countByArtist(Artist artist);
+
+    @Query("SELECT fa " +
+            "FROM FavoriteArtist fa " +
+            "JOIN FETCH fa.artist a " +
+            "JOIN FETCH a.user u " +
+            "WHERE fa.model = :model " +
+            "ORDER BY fa.createdAt desc")
+    Page<FavoriteArtist> findFavoriteArtistByModel(
+            @Param(value = "model") Model model,
+            Pageable pageable);
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/FavoritePortfolioRepository.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/FavoritePortfolioRepository.java
@@ -3,15 +3,27 @@ package org.meme.service.domain.repository;
 import org.meme.service.domain.entity.FavoritePortfolio;
 import org.meme.service.domain.entity.Model;
 import org.meme.service.domain.entity.Portfolio;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface FavoritePortfolioRepository extends JpaRepository<FavoritePortfolio, Long> {
-    List<FavoritePortfolio> findByModel(Model model);
     boolean existsByModelAndPortfolio(Model model, Portfolio portfolio);
     Optional<FavoritePortfolio> findByModelAndPortfolio(Model model, Portfolio portfolio);
+
+    @Query("SELECT fp " +
+            "FROM FavoritePortfolio fp " +
+            "JOIN FETCH fp.portfolio p " +
+            "JOIN FETCH p.portfolioImgList pil " +
+            "WHERE fp.model = :model " +
+            "ORDER BY fp.createdAt desc")
+    Page<FavoritePortfolio> findFavoritePortfolioByModel(
+            @Param(value = "model") Model model,
+            Pageable pageable);
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/ModelRepository.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/ModelRepository.java
@@ -2,11 +2,19 @@ package org.meme.service.domain.repository;
 
 import org.meme.service.domain.entity.Model;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
 @Repository
 public interface ModelRepository extends JpaRepository<Model, Long> {
+
+    @Query("SELECT m " +
+            "FROM Model m " +
+            "JOIN FETCH m.user " +
+            "WHERE m.userId = :userId")
+    Optional<Model> findModelByUserId(@Param(value = "userId") Long userId);
 
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/PortfolioRepository.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/PortfolioRepository.java
@@ -25,11 +25,6 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
             @Param(value = "artist") Artist artist,
             Pageable pageable);
 
-
-
-    @Query("SELECT p FROM Portfolio p WHERE p.isBlock = false")
-    Page<Portfolio> findAllNotBlocked(Pageable pageable);
-
     boolean existsByMakeupName(String makeupName);
 
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/PortfolioRepository.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/PortfolioRepository.java
@@ -2,7 +2,6 @@ package org.meme.service.domain.repository;
 
 import org.meme.service.domain.entity.Artist;
 import org.meme.service.domain.entity.Portfolio;
-import org.meme.service.domain.enums.Category;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,26 +9,35 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
-    @Query("SELECT p FROM Portfolio p " +
+
+    @Query("SELECT p " +
+            "FROM Portfolio p " +
+            "JOIN FETCH p.portfolioImgList pl " +
             "WHERE p.artist = :artist " +
-            "AND p.isBlock = false")
-    Page<Portfolio> findByArtist(@Param("artist") Artist artist, Pageable pageable);
+            "AND p.isBlock = false " +
+            "ORDER BY p.createdAt desc")
+    Page<Portfolio> findPortfoliosByArtist(
+            @Param(value = "artist") Artist artist,
+            Pageable pageable);
 
-    @Query("SELECT p FROM Portfolio p " +
-            "WHERE p.category = :category " +
-            "AND p.isBlock = false ")
-    Page<Portfolio> findByCategory(@Param("category") Category category, Pageable pageable);
 
-    @Query("SELECT p FROM Portfolio p " +
-            "WHERE (p.makeupName LIKE %:query% OR p.info LIKE %:query%) " +
-            "AND p.isBlock = false" )
-    Page<Portfolio> search(@Param("query") String query, Pageable pageable);
 
     @Query("SELECT p FROM Portfolio p WHERE p.isBlock = false")
     Page<Portfolio> findAllNotBlocked(Pageable pageable);
 
     boolean existsByMakeupName(String makeupName);
 
+
+    @Query("SELECT p " +
+            "FROM Portfolio p " +
+            "JOIN FETCH p.portfolioImgList pl " +
+            "JOIN FETCH p.artist a " +
+            "JOIN FETCH a.user u " +
+            "WHERE p.portfolioId = :portfolioId " +
+            "AND p.isBlock = false ")
+    Optional<Portfolio> findPortfolioById(@Param(value = "portfolioId") Long portfolioId);
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/PortfolioRepository.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/PortfolioRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -40,4 +41,23 @@ public interface PortfolioRepository extends JpaRepository<Portfolio, Long> {
             "WHERE p.portfolioId = :portfolioId " +
             "AND p.isBlock = false ")
     Optional<Portfolio> findPortfolioById(@Param(value = "portfolioId") Long portfolioId);
+
+
+    @Query("SELECT p " +
+            "FROM Portfolio p " +
+            "JOIN FETCH p.portfolioImgList pl " +
+            "JOIN FETCH p.artist a " +
+            "JOIN FETCH a.user u " +
+            "WHERE p.isBlock = false " +
+            "ORDER BY p.averageStars desc")
+    List<Portfolio> findPortfolioByReviewList();
+
+    @Query("SELECT p " +
+            "FROM Portfolio p " +
+            "JOIN FETCH p.portfolioImgList pl " +
+            "JOIN FETCH p.artist a " +
+            "JOIN FETCH a.user u " +
+            "WHERE p.isBlock = false " +
+            "ORDER BY p.createdAt desc")
+    List<Portfolio> findPortfolioByCreatedAt();
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/ReservationRepository.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/ReservationRepository.java
@@ -1,8 +1,6 @@
 package org.meme.service.domain.repository;
 
-import org.meme.service.domain.entity.Artist;
 import org.meme.service.domain.entity.Model;
-import org.meme.service.domain.entity.Portfolio;
 import org.meme.service.domain.entity.Reservation;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -15,16 +13,20 @@ import java.util.Optional;
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 
+    @Query("SELECT r " +
+            "FROM Reservation r " +
+            "JOIN FETCH r.portfolio p " +
+            "JOIN FETCH p.portfolioImgList pil " +
+            "JOIN FETCH p.artist a " +
+            "JOIN FETCH a.user u " +
+            "WHERE r.model = :model " +
+            "AND r.status = 'COMPLETED' " +
+            "ORDER BY r.createdAt desc")
+    List<Reservation> findReservationByStatus(@Param(value = "model") Model model);
+
     @Query("SELECT r FROM Reservation r JOIN r.model m WHERE r.reservationId = :reservationId AND m.userId = :modelId")
     Optional<Reservation> findByReservationIdAndModelId(@Param("reservationId") Long reservationId, @Param("modelId") Long modelId);
 
-    List<Reservation> findByModelAndPortfolio(Model model, Portfolio portfolio);
-
-    // 예약 겹치는 여부 체크
-    Optional<List<Reservation>> findByPortfolioAndYearAndMonthAndDay(Portfolio portfolio, int year, int month, int day);
-
-    // 연도, 월에 맞춰 예약 내역 불러오기
-    Optional<List<Reservation>> findByPortfolioAndYearAndMonth(Portfolio portfolio, int year, int month);
 }
 
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/ReservationRepository.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/ReservationRepository.java
@@ -14,11 +14,6 @@ import java.util.Optional;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
-    @Query("SELECT r FROM Reservation r WHERE r.portfolio.artist = :artist")
-    List<Reservation> findByArtist(@Param("artist") Artist artist);
-
-    @Query("SELECT r FROM Reservation r WHERE r.model = :model")
-    List<Reservation> findByModel(@Param("model") Model model);
 
     @Query("SELECT r FROM Reservation r JOIN r.model m WHERE r.reservationId = :reservationId AND m.userId = :modelId")
     Optional<Reservation> findByReservationIdAndModelId(@Param("reservationId") Long reservationId, @Param("modelId") Long modelId);

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/ReviewRepository.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/ReviewRepository.java
@@ -1,13 +1,47 @@
 package org.meme.service.domain.repository;
 
 import org.meme.service.domain.entity.Model;
+import org.meme.service.domain.entity.Portfolio;
 import org.meme.service.domain.entity.Review;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
-    List<Review> findByModel(Model model);
+
+    @Query("SELECT r " +
+            "FROM Review r " +
+            "JOIN FETCH r.reviewImgList ril " +
+            "JOIN FETCH r.portfolio p " +
+            "JOIN FETCH p.artist a " +
+            "JOIN FETCH a.user u " +
+            "WHERE r.model = :model " +
+            "ORDER BY r.createdAt desc ")
+    List<Review> findByModel(@Param(value = "model") Model model);
+
+    @Query("SELECT r " +
+            "FROM Review r " +
+            "JOIN FETCH r.reviewImgList ril " +
+            "WHERE r.portfolio = :portfolio " +
+            "ORDER BY r.createdAt desc ")
+    Page<Review> findReviewsByPortfolio(
+            @Param(value = "portfolio") Portfolio portfolio,
+            Pageable pageable);
+
+    @Query("SELECT r " +
+            "FROM Review r " +
+            "JOIN FETCH r.reviewImgList ril " +
+            "JOIN FETCH r.portfolio p " +
+            "JOIN FETCH p.artist a " +
+            "JOIN FETCH a.user u " +
+            "WHERE r.reviewId = :reviewId " +
+            "ORDER BY r.createdAt desc ")
+    Optional<Review> findReviewById(@Param(value = "reviewId") Long reviewId);
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/ReviewRepository.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/repository/ReviewRepository.java
@@ -29,6 +29,8 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     @Query("SELECT r " +
             "FROM Review r " +
             "JOIN FETCH r.reviewImgList ril " +
+            "JOIN FETCH r.model m " +
+            "JOIN FETCH m.user u " +
             "WHERE r.portfolio = :portfolio " +
             "ORDER BY r.createdAt desc ")
     Page<Review> findReviewsByPortfolio(

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/ArtistService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/ArtistService.java
@@ -2,7 +2,6 @@ package org.meme.service.domain.service;
 
 import lombok.RequiredArgsConstructor;
 import org.meme.service.common.status.ErrorStatus;
-import org.meme.service.domain.entity.FavoriteArtist;
 import org.meme.service.domain.entity.Model;
 import org.meme.service.domain.repository.ArtistRepository;
 import org.meme.service.domain.repository.FavoriteArtistRepository;
@@ -13,8 +12,6 @@ import org.springframework.stereotype.Service;
 import org.meme.service.domain.entity.Artist;
 import org.meme.service.common.exception.GeneralException;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -30,10 +27,7 @@ public class ArtistService {
         Model model = findModelById(userId);
         Artist artist = findArtistById(artistId);
 
-        boolean isFavorite = false;
-        Optional<FavoriteArtist> favoriteArtist = favoriteArtistRepository.findByModelAndArtist(model, artist);
-        if(favoriteArtist.isPresent())
-            isFavorite = true;
+        boolean isFavorite = favoriteArtistRepository.existsByModelAndArtist(model, artist);
 
         return ArtistConverter.toArtistDto(artist, isFavorite);
     }
@@ -45,7 +39,7 @@ public class ArtistService {
     }
 
     private Artist findArtistById(Long artistId){
-        return artistRepository.findById(artistId)
+        return artistRepository.findArtistByUserId(artistId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_EXIST_ARTIST));
     }
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/ArtistService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/ArtistService.java
@@ -50,7 +50,7 @@ public class ArtistService {
     }
 
     private Model findModelById(Long modelId){
-        return modelRepository.findById(modelId)
+        return modelRepository.findModelByUserId(modelId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_EXIST_MODEL));
     }
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/FavoriteService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/FavoriteService.java
@@ -67,11 +67,7 @@ public class FavoriteService {
     public void addFavoriteArtist(FavoriteRequest.FavoriteArtistDto favoriteArtistDto) {
         Model model = findModelById(favoriteArtistDto.getModelId());
         Artist artist = findArtistById(favoriteArtistDto.getArtistId());
-
-        //이미 관심 아티스트가 존재하는 경우
-        if (favoriteArtistRepository.existsByModelAndArtist(model, artist)) {
-            throw new GeneralException(ErrorStatus.ALREADY_EXIST_FAVORITE_ARTIST);
-        }
+        validExistFavoriteArtist(model, artist);
 
         FavoriteArtist favoriteArtist = FavoriteConverter.toFavoriteArtist(artist, model);
         model.updateFavoriteArtistList(favoriteArtist);
@@ -83,11 +79,7 @@ public class FavoriteService {
     public void addFavoritePortfolio(FavoriteRequest.FavoritePortfolioDto favoritePortfolioDto) {
         Model model = findModelById(favoritePortfolioDto.getModelId());
         Portfolio portfolio = findPortfolioById(favoritePortfolioDto.getPortfolioId());
-
-        //이미 관심 포트폴리오가 존재하는 경우
-        if (favoritePortfolioRepository.existsByModelAndPortfolio(model,portfolio)) {
-            throw new GeneralException(ErrorStatus.ALREADY_EXIST_FAVORITE_PORTFOLIO);
-        }
+        validExistFavoritePortfolio(model, portfolio);
 
         FavoritePortfolio favoritePortfolio = FavoriteConverter.toFavoritePortfolio(model, portfolio);
         model.updateFavoritePortfolioList(favoritePortfolio);
@@ -112,6 +104,20 @@ public class FavoriteService {
 
         FavoritePortfolio favoritePortfolio = findFavoritePortfolioByModelAndPortfolio(model, portfolio);
         favoritePortfolioRepository.delete(favoritePortfolio);
+    }
+
+    private void validExistFavoritePortfolio(Model model, Portfolio portfolio) {
+        //이미 관심 포트폴리오가 존재하는 경우
+        if (favoritePortfolioRepository.existsByModelAndPortfolio(model,portfolio)) {
+            throw new GeneralException(ErrorStatus.ALREADY_EXIST_FAVORITE_PORTFOLIO);
+        }
+    }
+
+    private void validExistFavoriteArtist(Model model, Artist artist) {
+        //이미 관심 아티스트가 존재하는 경우
+        if (favoriteArtistRepository.existsByModelAndArtist(model, artist)) {
+            throw new GeneralException(ErrorStatus.ALREADY_EXIST_FAVORITE_ARTIST);
+        }
     }
 
     private Artist findArtistById(Long artistId){

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/FavoriteService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/FavoriteService.java
@@ -11,7 +11,6 @@ import org.meme.service.domain.dto.response.ArtistResponse;
 import org.meme.service.domain.dto.request.FavoriteRequest;
 import org.meme.service.domain.dto.response.FavoriteResponse;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -39,6 +38,7 @@ public class FavoriteService {
         Pageable pageable = PageRequest.of(page, pageSize);
         Page<FavoriteArtist> favoriteArtistPage = favoriteArtistRepository.findFavoriteArtistByModel(model, pageable);
 
+        // TODO:
         //관심 아티스트 리스트
         List<ArtistResponse.ArtistSimpleDto> content = favoriteArtistPage.getContent().stream()
                 .map(favoriteArtist -> {
@@ -137,17 +137,6 @@ public class FavoriteService {
     private FavoriteArtist findFavoriteArtistByModelAndArtist(Model model, Artist artist){
         return favoriteArtistRepository.findByModelAndArtist(model, artist)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_EXIST_FAVORITE_ARTIST));
-    }
-
-    private Page getPage(int page, List list){
-        Pageable pageable = PageRequest.of(page, 30);
-
-        int start = (int) pageable.getOffset();
-        int end = Math.min((start + pageable.getPageSize()), list.size());
-
-        //list를 page로 변환
-        return new PageImpl<>(list.subList(start, end),
-                pageable, list.size());
     }
 
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/FavoriteService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/FavoriteService.java
@@ -123,7 +123,7 @@ public class FavoriteService {
     }
 
     private Model findModelById(Long modelId){
-        return modelRepository.findById(modelId)
+        return modelRepository.findModelByUserId(modelId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_EXIST_MODEL));
     }
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/FavoriteService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/FavoriteService.java
@@ -118,7 +118,7 @@ public class FavoriteService {
     }
 
     private Artist findArtistById(Long artistId){
-        return artistRepository.findById(artistId)
+        return artistRepository.findArtistByUserId(artistId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_EXIST_ARTIST));
     }
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/FavoriteService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/FavoriteService.java
@@ -29,16 +29,15 @@ public class FavoriteService {
     private final FavoriteArtistRepository favoriteArtistRepository;
     private final FavoritePortfolioRepository favoritePortfolioRepository;
     private final PortfolioRepository portfolioRepository;
+    private final int pageSize = 30;
 
 
     //관심 아티스트 조회
-    @Transactional
     public FavoriteResponse.FavoriteArtistPageDto getFavoriteArtist(Long modelId, int page){
         Model model = findModelById(modelId);
 
-        //paging
-        List<FavoriteArtist> favoriteArtistList = model.getFavoriteArtistList();
-        Page<FavoriteArtist> favoriteArtistPage = getPage(page, favoriteArtistList);
+        Pageable pageable = PageRequest.of(page, pageSize);
+        Page<FavoriteArtist> favoriteArtistPage = favoriteArtistRepository.findFavoriteArtistByModel(model, pageable);
 
         //관심 아티스트 리스트
         List<ArtistResponse.ArtistSimpleDto> content = favoriteArtistPage.getContent().stream()
@@ -54,13 +53,11 @@ public class FavoriteService {
     }
 
     //관심 메이크업 조회
-    @Transactional
     public FavoriteResponse.FavoritePortfolioPageDto getFavoritePortfolio(Long modelId, int page){
         Model model = findModelById(modelId);
 
-        //list를 page로 변환
-        List<FavoritePortfolio> favoritePortfolioList = model.getFavoritePortfolioList();
-        Page<FavoritePortfolio> favoritePortfolioPage = getPage(page, favoritePortfolioList);
+        Pageable pageable = PageRequest.of(page, pageSize);
+        Page<FavoritePortfolio> favoritePortfolioPage = favoritePortfolioRepository.findFavoritePortfolioByModel(model, pageable);
 
         return FavoriteConverter.toFavoritePortfolioPageDto(favoritePortfolioPage);
     }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/MypageService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/MypageService.java
@@ -83,37 +83,31 @@ public class MypageService {
     }
 
     private void updateModelEntity(Model model, MypageRequest.ModelProfileDto request) {
-        if (request.getProfileImg() != null)
-            model.updateProfileImg(request.getProfileImg());
-        if (request.getNickname() != null)
-            model.updateNickname(request.getNickname());
-        if (request.getGender() != null)
-            model.updateGender(request.getGender());
-        if (request.getSkinType() != null)
-            model.setSkinType(request.getSkinType());
-        if (request.getPersonalColor() != null)
-            model.setPersonalColor(request.getPersonalColor());
+        model.getUser().updateProfileImg(request.getProfileImg());
+        model.getUser().updateNickname(request.getNickname());
+        model.getUser().updateGender(request.getGender());
+        model.updateSkinType(request.getSkinType());
+        model.updatePersonalColor(request.getPersonalColor());
     }
 
     private void updateArtistEntity(Artist artist, MypageRequest.ArtistProfileDto request) {
-        if (request.getProfileImg() != null)
-            artist.updateProfileImg(request.getProfileImg());
-        if (request.getNickname() != null)
-            artist.updateNickname(request.getNickname());
-        if (request.getGender() != null)
-            artist.updateGender(request.getGender());
-        if (request.getIntroduction() != null)
-            artist.setIntroduction(request.getIntroduction());
-        if (request.getWorkExperience() != null)
-            artist.setWorkExperience(request.getWorkExperience());
-        if (request.getRegion() != null)
-            artist.setRegion(request.getRegion());
-        if (request.getSpecialization() != null)
-            artist.setSpecialization(request.getSpecialization());
-        if (request.getMakeupLocation() != null)
-            artist.setMakeupLocation(request.getMakeupLocation());
-        if (request.getShopLocation() != null)
-            artist.setShopLocation(request.getShopLocation());
+        artist.getUser().updateProfileImg(request.getProfileImg());
+        artist.getUser().updateNickname(request.getNickname());
+        artist.getUser().updateGender(request.getGender());
+
+        validIntroductionLength(request.getIntroduction());
+        artist.updateIntroduction(request.getIntroduction());
+        artist.updateWorkExperience(request.getWorkExperience());
+        artist.updateRegion(request.getRegion());
+        artist.updateSpecialization(request.getSpecialization());
+        artist.updateMakeupLocation(request.getMakeupLocation());
+        artist.updateShopLocation(request.getShopLocation());
+    }
+
+    private void validIntroductionLength(String introduction) {
+        if (introduction != null && introduction.length() > 500) {
+            throw new GeneralException(ErrorStatus.OVERFLOW_ARTIST_INTRODUCTION);
+        }
     }
 
     private User findUserById(Long userId){

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/MypageService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/MypageService.java
@@ -122,7 +122,7 @@ public class MypageService {
     }
 
     private Artist findArtistById(Long artistId){
-        return artistRepository.findById(artistId)
+        return artistRepository.findArtistByUserId(artistId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_EXIST_ARTIST));
     }
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/MypageService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/MypageService.java
@@ -127,7 +127,7 @@ public class MypageService {
     }
 
     private Model findModelById(Long modelId){
-        return modelRepository.findById(modelId)
+        return modelRepository.findModelByUserId(modelId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_EXIST_MODEL));
     }
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/PortfolioService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/PortfolioService.java
@@ -176,7 +176,7 @@ public class PortfolioService {
         if (portfolio.getArtist() != artist)
             throw new GeneralException(ErrorStatus.NOT_AUTHORIZED_PORTFOLIO);
 
-        portfolio.setBlock(!portfolio.isBlock());
+        portfolio.updateBlock(!portfolio.isBlock());
     }
 
     private Artist findArtistById(Long artistId){
@@ -220,14 +220,10 @@ public class PortfolioService {
     }
 
     private void updatePortfolioEntity(Portfolio portfolio, PortfolioRequest.UpdatePortfolioDto request) {
-        if(request.getCategory() != null)
-            portfolio.setCategory(request.getCategory());
-        if(request.getPrice() >= 0)
-            portfolio.setPrice(request.getPrice());
-        if(request.getInfo() != null)
-            portfolio.setInfo(request.getInfo());
-        if(request.getMakeupName() != null)
-            portfolio.setMakeupName(request.getMakeupName());
-        portfolio.setBlock(request.getIsBlock());
+        portfolio.updateCategory(request.getCategory());
+        portfolio.updatePrice(request.getPrice());
+        portfolio.updateInfo(request.getInfo());
+        portfolio.updateMakeupName(request.getMakeupName());
+        portfolio.updateBlock(request.getIsBlock());
     }
 }

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/PortfolioService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/PortfolioService.java
@@ -65,10 +65,7 @@ public class PortfolioService {
         // 아티스트의 전체 포트폴리오 리스트 조회
         Pageable pageable = PageRequest.of(page, pageSize);
         Page<Portfolio> portfolioList = portfolioRepository.findPortfoliosByArtist(artist, pageable);
-
-        //검색 결과가 없을 시
-        if(portfolioList.getContent().isEmpty())
-            throw new GeneralException(ErrorStatus.SEARCH_NOT_FOUNT);
+        validExistPortfolio(portfolioList.getContent());
 
         return PortfolioConverter.toPortfolioPageDto(portfolioList);
     }
@@ -156,10 +153,15 @@ public class PortfolioService {
     public void blockPortfolio(Long userId, Long portfolioId){
         Artist artist = findArtistById(userId);
         Portfolio portfolio = findPortfolioById(portfolioId);
-
         validArtistAuthorizedForPortfolio(portfolio, artist);
 
         portfolio.updateBlock(!portfolio.isBlock());
+    }
+
+    private void validExistPortfolio(List<Portfolio> portfolioList) {
+        //검색 결과가 없을 시
+        if(portfolioList.isEmpty())
+            throw new GeneralException(ErrorStatus.SEARCH_NOT_FOUNT);
     }
 
     private void validArtistAuthorizedForPortfolio(Portfolio portfolio, Artist artist) {

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/PortfolioService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/PortfolioService.java
@@ -140,20 +140,18 @@ public class PortfolioService {
      **/
     //리뷰 많은 순 포트폴리오 추천
     public List<PortfolioResponse.PortfolioSimpleDto> recommendReview() {
-        Pageable pageable = setPageRequest(0, "review");
-        Page<Portfolio> portfolioList = portfolioRepository.findAllNotBlocked(pageable);
+        List<Portfolio> portfolioList = portfolioRepository.findPortfolioByReviewList();
 
-        return portfolioList.getContent().stream()
+        return portfolioList.stream()
                 .map(PortfolioConverter::toPortfolioSimpleDto)
                 .toList();
     }
 
     //최신 등록 순 포트폴리오 추천
     public List<PortfolioResponse.PortfolioSimpleDto> recommendRecent() {
-        Pageable pageable = setPageRequest(0, "recent");
-        Page<Portfolio> portfolioList = portfolioRepository.findAllNotBlocked(pageable);
+        List<Portfolio> portfolioList = portfolioRepository.findPortfolioByCreatedAt();
 
-        return portfolioList.getContent().stream()
+        return portfolioList.stream()
                 .map(PortfolioConverter::toPortfolioSimpleDto)
                 .toList();
     }
@@ -183,31 +181,6 @@ public class PortfolioService {
     private Portfolio findPortfolioById(Long portfolioId){
         return portfolioRepository.findPortfolioById(portfolioId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_EXIST_PORTFOLIO));
-    }
-
-    private Pageable setPageRequest(int page, String sortBy) {
-
-        Sort sort = switch (sortBy) {
-            case "desc" -> Sort.by("price").descending();
-            case "asc" -> Sort.by("price").ascending();
-            case "review" -> Sort.by("averageStars").descending();
-            case "recent" -> Sort.by("createdAt").descending();
-            default -> throw new GeneralException(ErrorStatus.INVALID_SORT_CRITERIA);
-        };
-
-        //별점 높은 순 정렬 추가
-        Sort finalSort = sort.and(Sort.by("averageStars").descending());
-        return PageRequest.of(page, 30, finalSort);
-    }
-
-    private Page<Portfolio> getPage(int page, List<Portfolio> list) {
-        Pageable pageable = PageRequest.of(page, 30);
-
-        int start = (int) pageable.getOffset();
-        int end = Math.min((start + pageable.getPageSize()), list.size());
-
-        return new PageImpl<>(list.subList(start, end),
-                pageable, list.size());
     }
 
     private void updatePortfolioEntity(Portfolio portfolio, PortfolioRequest.UpdatePortfolioDto request) {

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/ReviewService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/ReviewService.java
@@ -10,7 +10,6 @@ import org.meme.service.domain.dto.request.ReviewRequest;
 import org.meme.service.domain.dto.response.ReviewResponse;
 import org.meme.service.domain.repository.PortfolioRepository;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -83,9 +82,8 @@ public class ReviewService {
     public ReviewResponse.ReviewListPageDto getReviewList(Long portfolioId, int page) {
         Portfolio portfolio = findPortfolioById(portfolioId);
 
-        // list를 page로 변환
-        List<Review> reviewList = portfolio.getReviewList();
-        Page<Review> reviewPage = getPage(page, reviewList);
+        Pageable pageable = PageRequest.of(page, 30);
+        Page<Review> reviewPage = reviewRepository.findReviewsByPortfolio(portfolio, pageable);
 
         return ReviewConverter.toReviewListPageDto(reviewPage);
     }
@@ -188,24 +186,13 @@ public class ReviewService {
     }
 
     private Review findReviewById(Long reviewId){
-        return reviewRepository.findById(reviewId)
+        return reviewRepository.findReviewById(reviewId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_EXIST_REVIEW));
     }
 
     private Reservation findReservationByIdAndModel(Long reservationId, Long modelId){
         return reservationRepository.findByReservationIdAndModelId(reservationId, modelId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_EXIST_RESERVATION));
-    }
-
-    private Page<Review> getPage(int page, List<Review> list){
-        Pageable pageable = PageRequest.of(page, 30);
-
-        int start = (int) pageable.getOffset();
-        int end = Math.min((start + pageable.getPageSize()), list.size());
-
-        //list를 page로 변환
-        return new PageImpl<>(list.subList(start, end),
-                pageable, list.size());
     }
 
     private void updateReview(Review review, ReviewRequest.UpdateReviewDto updateReviewDto){

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/ReviewService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/ReviewService.java
@@ -54,6 +54,7 @@ public class ReviewService {
         // 리뷰 연관관게 설정
         portfolio.updateReviewList(review);
         model.updateReviewList(review);
+        portfolio.updateReviewCount();
 
         reviewRepository.save(review);
 

--- a/MEME-SERVICE/src/main/java/org/meme/service/domain/service/ReviewService.java
+++ b/MEME-SERVICE/src/main/java/org/meme/service/domain/service/ReviewService.java
@@ -178,7 +178,7 @@ public class ReviewService {
     }
 
     private Model findModelById(Long modelId){
-        return modelRepository.findById(modelId)
+        return modelRepository.findModelByUserId(modelId)
                 .orElseThrow(() -> new GeneralException(ErrorStatus.NOT_EXIST_MODEL));
     }
 


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
closed #53 

## ✨ 이슈 내용
<!-- 이슈에 대한 설명을 적어주세요 -->
- `User`, `Artist`, `Model` 필드 변경 로직 entity 내부에 위치하도록 수정 / `@Setter` 제거
- `Portfolio` 도메인 조회 성능 개선
  - `Long reviewCount` 필드 추가 
    - 조회할 때마다 카운트 쿼리 나가는 것이 너무 불필요하다고 생각되어 count 필드를 추가했습니다. 
- `Review` 도메인 조회 성능 개선
- `Favorite` 도메인 조회 성능 개선
- 마이페이지 조회 관련 기능 성능 개선
- 예외처리 관련 함수 서브 로직으로 분리



## 📚 논의할 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
- `Artist` 관련 정보를 조회할 때, Region, Category 리스트 조회 쿼리가 항상 함께 나가서 어떻게 줄여야 할까 고민입니다
- `ReviewImg`, `PortfolioImg` 관련 부분은 차차 리팩토링 진행하겠습니다
- 관심 아티스트 리스트 조회 로직 추후 수정할 계획입니다
- 객체 삭제 시 CASCADE에 의한 delete 쿼리 개선 예정입니다
